### PR TITLE
Remove copy bounds from `CorrodedArray::default` implementation

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -146,10 +146,10 @@ impl<T, const N: usize> CorrodedArray<T, N> {
     }
 }
 
-impl<T: Default + Copy, const N: usize> Default for CorrodedArray<T, N> {
+impl<T: Default, const N: usize> Default for CorrodedArray<T, N> {
     fn default() -> Self {
         CorrodedArray {
-            inner: [T::default(); N],
+            inner: core::array::from_fn(|_| T::default()),
         }
     }
 }


### PR DESCRIPTION
I noticed this in my reading of this very perfectly made library, and saw we could make this implementation even more relaxed